### PR TITLE
Indicate byte array inputs are supported too

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Usage
 
 ### ripemd160(input)
 
-Input either a string or `Buffer`. Output is a `Buffer`.
+Input either a string, `Buffer` or byte array. Output is a `Buffer`.
 
 ```js
 console.log(ripemd160("hello").toString('hex')) // => 108f07b8382412612c048d07d13f814118445acd"
@@ -29,8 +29,3 @@ Credits
 -------
 
 Most of the code from CryptoJS https://code.google.com/p/crypto-js/
-
-
-
-
-


### PR DESCRIPTION
I was going to write a wrapper function in my application that adds support for that, but noticed that it already does support that - the input is processed by `bytesToWords`, which works well with byte arrays. I updated the README to indicate that.

One other thing that should perhaps be looked into is the different APIs that the SHA256 and RIPEMD160 modules expose. SHA256 can return multiple formats, but doesn't support Buffers, while RIPEMD160 only returns buffers. It probably makes sense to unify the interfaces (imho, I think its best to always return buffers and let the user handle other formats in app-land), but it'll probably break some code that depends on that.
