### PR TITLE
Add BSD license to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "bytes",
     "cryptography"
   ],
+  "license": "BSD-3",
   "devDependencies": {
     "mocha": "~1.17.1",
     "terst": "~0.1.0",


### PR DESCRIPTION
The license matches the BSD-3 license (3-clause license ("Revised BSD License", "New BSD License", or "Modified BSD License")) which is also used in the CryptoJS library.

Adding the license to package.json makes ripemd160 compatible with various license tools.
