### PR TITLE
Don't use the deprecated Buffer() constructor

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 'use strict'
+var Buffer = require('buffer').Buffer
 var inherits = require('inherits')
 var HashBase = require('hash-base')
 

--- a/index.js
+++ b/index.js
@@ -126,7 +126,7 @@ RIPEMD160.prototype._digest = function () {
   this._update()
 
   // produce result
-  var buffer = new Buffer(20)
+  var buffer = Buffer.alloc ? Buffer.alloc(20) : new Buffer(20)
   buffer.writeInt32LE(this._a, 0)
   buffer.writeInt32LE(this._b, 4)
   buffer.writeInt32LE(this._c, 8)


### PR DESCRIPTION
Use Buffer.alloc instead when available.

Ref: nodejs/node#19079
Ref: https://nodejs.org/api/deprecations.html#deprecations_dep0005_buffer_constructor
Ref: https://nodejs.org/api/buffer.html#buffer_class_buffer
Ref: https://github.com/ChALkeR/safer-buffer/blob/master/Porting-Buffer.md